### PR TITLE
add go.mod file, start building in module mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ language: go
 go:
   - 1.x
   - master
+env:
+  - GO111MODULE=on
 matrix:
   allow_failures:
     - go: master
   fast_finish: true
-install:
-  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
-  - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
   - go vet ./...
   - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ matrix:
   allow_failures:
     - go: master
   fast_finish: true
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening.
 script:
+  - git clone https://github.com/shurcooL/frontend "$GOPATH/src/github.com/shurcooL/frontend" || (cd "$GOPATH/src/github.com/shurcooL/frontend" && git pull --ff-only)  # TODO: remove after golang.org/issue/31603 is resolved
   - diff -u <(echo -n) <(gofmt -d -s .)
   - go vet ./...
   - go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation
 ...
 
 # Step back and enjoy 1 command that installs Conception-go and all its dependencies.
-go get -u github.com/shurcooL-legacy/Conception-go
+GO111MODULE=on go install github.com/shurcooL-legacy/Conception-go
 
 # Run it.
 $(go env GOPATH)/bin/Conception-go
@@ -47,7 +47,7 @@ sudo apt-get install --yes git
 sudo apt-get install --yes libgl1-mesa-dev xorg-dev # OpenGL headers.
 
 # Step back and enjoy 1 command that installs Conception-go and all its dependencies.
-go get -u github.com/shurcooL-legacy/Conception-go
+GO111MODULE=on go install github.com/shurcooL-legacy/Conception-go
 
 # Run it.
 $(go env GOPATH)/bin/Conception-go

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Installation
 # Install latest Go, git (if you don't already have them).
 ...
 
-# Step back and enjoy 1 command that installs Conception-go and all its dependencies.
-GO111MODULE=on go install github.com/shurcooL-legacy/Conception-go
+# Step back and enjoy 2 commands that install Conception-go.
+git clone https://github.com/shurcooL/frontend "$GOPATH/src/github.com/shurcooL/frontend" || (cd "$GOPATH/src/github.com/shurcooL/frontend" && git pull --ff-only)  # TODO: remove after golang.org/issue/31603 is resolved
+(cd; GO111MODULE=on go install github.com/shurcooL-legacy/Conception-go)
 
 # Run it.
 $(go env GOPATH)/bin/Conception-go
@@ -39,15 +40,16 @@ $(go env GOPATH)/bin/Conception-go
 ```bash
 # Install latest Go (if you don't already have it).
 sudo apt-get install --yes curl
-curl -L https://golang.org/dl/go1.9.linux-amd64.tar.gz | sudo tar zx -C /usr/local/
+curl -L https://golang.org/dl/go1.12.4.linux-amd64.tar.gz | sudo tar zx -C /usr/local/
 export PATH="$PATH:/usr/local/go/bin"
 
 # Install git, OpenGL headers (if you don't already have them).
 sudo apt-get install --yes git
 sudo apt-get install --yes libgl1-mesa-dev xorg-dev # OpenGL headers.
 
-# Step back and enjoy 1 command that installs Conception-go and all its dependencies.
-GO111MODULE=on go install github.com/shurcooL-legacy/Conception-go
+# Step back and enjoy 2 commands that install Conception-go.
+git clone https://github.com/shurcooL/frontend "$GOPATH/src/github.com/shurcooL/frontend" || (cd "$GOPATH/src/github.com/shurcooL/frontend" && git pull --ff-only)  # TODO: remove after golang.org/issue/31603 is resolved
+(cd; GO111MODULE=on go install github.com/shurcooL-legacy/Conception-go)
 
 # Run it.
 $(go env GOPATH)/bin/Conception-go

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,45 @@
+module github.com/shurcooL-legacy/Conception-go
+
+go 1.12
+
+require (
+	github.com/bradfitz/iter v0.0.0-20190303215204-33e6a9893b0c
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7
+	github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1
+	github.com/go-gl/mathgl v0.0.0-20190416160123-c4601bc793c7
+	github.com/gopherjs/gopherjs v0.0.0-20190411002643-bd77b112433e // indirect
+	github.com/goxjs/gl v0.0.0-20171128034433-dc8f4a9a3c9c
+	github.com/goxjs/glfw v0.0.0-20171018044755-7dec05603e06
+	github.com/kisielk/gotool v1.0.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mattn/go-runewidth v0.0.4
+	github.com/mb0/diff v0.0.0-20131118162322-d8d9a906c24d
+	github.com/microcosm-cc/bluemonday v1.0.2 // indirect
+	github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86 // indirect
+	github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab // indirect
+	github.com/pkg/math v0.0.0-20141027224758-f2ed9e40e245
+	github.com/sergi/go-diff v1.0.0
+	github.com/shurcooL-legacy/octicons v0.0.0-20180602233653-10c8018fdc76
+	github.com/shurcooL/frontend v0.0.0-20180531171852-7e359e4b7b17
+	github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470
+	github.com/shurcooL/go v0.0.0-20190330031554-6713ea532688
+	github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041
+	github.com/shurcooL/gopherjslib v0.0.0-20160914041154-feb6d3990c2c // indirect
+	github.com/shurcooL/highlight_diff v0.0.0-20181222201841-111da2e7d480 // indirect
+	github.com/shurcooL/highlight_go v0.0.0-20181215221002-9d8641ddf2e1
+	github.com/shurcooL/httpfs v0.0.0-20181222201310-74dc9339e414
+	github.com/shurcooL/httpgzip v0.0.0-20180522190206-b1c53ac65af9
+	github.com/shurcooL/markdownfmt v0.0.0-20190409060426-3438a10682f5
+	github.com/shurcooL/octicon v0.0.0-20181222203144-9ff1a4cf27f4 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d // indirect
+	github.com/sourcegraph/go-diff v0.5.1
+	github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e
+	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/net v0.0.0-20190420063019-afa5a82059c6
+	golang.org/x/tools v0.0.0-20190420181800-aa740d480789
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/pipe.v2 v2.0.0-20140414041502-3c2ca4d52544
+	honnef.co/go/js/dom v0.0.0-20190403051653-d6d651dc5aea // indirect
+)

--- a/install-into-bundle.sh
+++ b/install-into-bundle.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-GOBIN="$HOME/Dropbox/Applications/Conception.app/Contents/MacOS" go install -v
+GO111MODULE=on GOPATH="$HOME/Library/Caches/go" GOBIN="$HOME/Dropbox/Applications/Conception.app/Contents/MacOS" go install -v

--- a/pkg/gist5504644/main.go
+++ b/pkg/gist5504644/main.go
@@ -66,7 +66,7 @@ func BuildPackageFromImportPathBuildTags(importPath string, buildTags []string) 
 func BuildPackageFromImportPath(importPath string) (bpkg *build.Package, err error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return build.Import(importPath, wd, importMode)
 }

--- a/pkg/gist5504644/main.go
+++ b/pkg/gist5504644/main.go
@@ -7,6 +7,7 @@ import (
 	"go/doc"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
 	"sync"
 )
@@ -63,7 +64,11 @@ func BuildPackageFromImportPathBuildTags(importPath string, buildTags []string) 
 }
 
 func BuildPackageFromImportPath(importPath string) (bpkg *build.Package, err error) {
-	return build.Import(importPath, "", importMode)
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	return build.Import(importPath, wd, importMode)
 }
 
 func BuildPackageFromSrcDir(srcDir string) (bpkg *build.Package, err error) {


### PR DESCRIPTION
When using the GOPATH mode, unless one vendors all dependencies or
uses third-party dependency management tools, there is no viable
choice but to always automatically opt-in to latest versions of
all dependencies by relying on the `go get -u` command.

That is actually desirable behavior for most of my actively developed
and actively maintained projects, because it means I don't have to do
extra work of checking for newer versions of dependencies and updating
to them when they come out; that happens automatically and implicitly.
It reduces my work and removes the chance of me forgetting to update.
It helps detect breakages as soon as possible and keeps my overall
maintenance costs down. It has the cost of the project being potentially
broken for some short amount of time (but well within my 95%+ yearly
uptime SLA, stated at https://github.com/shurcooL/SLA), but that's
an acceptable trade-off for me.

However, that behavior means a new version of a dependency may come
out that breaks the build, and I'd have to spend time on fixing
Conception-go. Since Conception-go is a legacy project, that is not
wanted.

Solve this problem by switching to using module mode for building
Conception-go. It results in reproducible builds and doesn't
automatically opt-in to newer versions of dependencies.

Note, however, that Conception-go itself still expects Go packages
that it operates on to be available in a GOPATH workspace.
Updating Conception-go to be compatible with Go's module mode is
not currently planned (because it's a frozen legacy project).